### PR TITLE
Should Contain

### DIFF
--- a/jspringbot-selenium/src/main/java/org/jspringbot/keyword/selenium/ElementAttributeValueShouldContain.java
+++ b/jspringbot-selenium/src/main/java/org/jspringbot/keyword/selenium/ElementAttributeValueShouldContain.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2012. JSpringBot. All Rights Reserved.
+ *
+ * See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The JSpringBot licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jspringbot.keyword.selenium;
+
+import org.jspringbot.KeywordInfo;
+import org.springframework.stereotype.Component;
+
+@Component
+@KeywordInfo(
+        name = "Element Attribute Value Should Contain",
+        parameters = {"locator", "expectedValue"},
+        description = "classpath:desc/ElementAttributeValueShouldContain.txt"
+)
+public class ElementAttributeValueShouldContain extends AbstractSeleniumKeyword {
+
+    @Override
+    public Object execute(Object[] params) {
+        helper.elementAttributeValueShouldContain(String.valueOf(params[0]),String.valueOf(params[1]));
+
+        return null;
+    }
+}

--- a/jspringbot-selenium/src/main/java/org/jspringbot/keyword/selenium/SeleniumHelper.java
+++ b/jspringbot-selenium/src/main/java/org/jspringbot/keyword/selenium/SeleniumHelper.java
@@ -491,7 +491,7 @@ public class SeleniumHelper {
             throw new AssertionError("Page should have contained text but did not.");
         }
     }
-
+    
     public void elementShouldContain(String locator, String expected) {
         String actual = getText(locator, false);
 
@@ -501,10 +501,14 @@ public class SeleniumHelper {
                 .appendProperty("Actual", actual)
                 .appendProperty("Expected", expected)
                 .log();
-
-        if (!expected.equalsIgnoreCase(actual)) {
-            throw new AssertionError("Element should have contained text.");
+       
+        if(!StringUtils.contains(StringUtils.trim(actual), StringUtils.trim(expected))) {
+        	throw new AssertionError("Element should have contained text.");
         }
+                
+//        if (!expected.equalsIgnoreCase(actual)) {
+//            throw new AssertionError("Element should have contained text.");
+//        }
     }
 
     public void elementShouldContainClass(String locator, String expectedClassName) {
@@ -641,11 +645,25 @@ public class SeleniumHelper {
         .log();
 
 		if (!StringUtils.equals(StringUtils.trim(actualValue), StringUtils.trim(expectedValue))) {
-		    throw new AssertionError("The text of element is not as expected.");
+		    throw new AssertionError("The attribute value of the element is not as expected.");
 		}
     }
     
-    
+    public void elementAttributeValueShouldContain(String attributeLocator, String expectedValue){
+    	
+    	String actualValue = getElementAttribute(attributeLocator);
+    	
+        LOG.createAppender()
+        .appendBold("Element Attribute Value Should Contain:")
+        .appendCss(attributeLocator)
+        .appendProperty("Actual Element Attribute Value", actualValue)
+        .appendProperty("Expected Element Attribute Value", expectedValue)
+        .log();
+
+        if(!StringUtils.contains(StringUtils.trim(actualValue), StringUtils.trim(expectedValue))) {
+        	throw new AssertionError("Element attribute value should have contained text.");
+        }
+    }
 
     public int getHorizontalPosition(String locator) {
         WebElement element = finder.find(locator);

--- a/jspringbot-selenium/src/main/resources/desc/ElementAttributeValueShouldContain.txt
+++ b/jspringbot-selenium/src/main/resources/desc/ElementAttributeValueShouldContain.txt
@@ -1,0 +1,3 @@
+Verifies if the element attribute value identified by locator contains text expected.
+
+If you wish to assert an exact (not a substring) match on the attribute value of an element, use `Element Attribute Value Should Be`.


### PR DESCRIPTION
Element Should Contain
- Fixed functionality to match with its documentation-- it
  checks previously if both strings are equal, basically the same
  as Element Should Be

Element Attribute Value Should Contain
- same functionality as element should contain, this time
  with element attribute values
